### PR TITLE
main: fix json encoding

### DIFF
--- a/main.py
+++ b/main.py
@@ -97,5 +97,5 @@ for i in range(len(df)):
     df_json["events"].append(df.iloc[i].to_dict())
 
     
-with open('output.json', 'w', encoding='utf-16') as f:
+with open('output.json', 'w', encoding='utf-8') as f:
     json.dump(df_json, f, indent=3, ensure_ascii=False)


### PR DESCRIPTION
It was switched from locale encoding to utf-16 in 6ce2e218c68ff7e. While in theory utf-16 works with some JSON tooling, it's no supported by discover.dnaustria, see https://handbuch.discover.dnaustria.at/json-erstellen/

Switch to utf-8 instead.